### PR TITLE
Feature/iat 268

### DIFF
--- a/application.yml
+++ b/application.yml
@@ -45,6 +45,7 @@ itembank:
 
 ivs:
   host: "${IVS_HOST:http://localhost:8200}"
+  externalHost: "${IVS_HOST:http://localhost:8200}"
   reloadEndpoint: "${IVS_RELOAD_ENDPOINT:/Pages/API/content/reload}"
   itemMapping: "${IVS_ITEM_MAPPING:/item}"
   ivsBaseDir: "${IVS_BASE_DIR:${HOME}/ItemBankIVS}"

--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ repositories {
 }
 
 dependencies {
-    compile 'org.opentestsystem.ap:ap-common:0.1.5-SNAPSHOT'
+    compile 'org.opentestsystem.ap:ap-common:0.1.8-SNAPSHOT'
 
     compile 'org.springframework.boot:spring-boot-starter-actuator'
     compile 'org.springframework.boot:spring-boot-starter-security'

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ description=Renders items from the item bank.
 
 group=org.opentestsystem.ap
 
-version=0.1.0-SNAPSHOT
+version=0.1.1-SNAPSHOT
 
 configServerVersion=0.0.1
 

--- a/src/main/java/org/opentestsystem/ap/irs/client/IvsClient.java
+++ b/src/main/java/org/opentestsystem/ap/irs/client/IvsClient.java
@@ -46,7 +46,7 @@ public class IvsClient {
     }
 
     public String getRenderUrl(String itemId) {
-        return ivsServiceProps.getHost() + ivsServiceProps.getItemMapping() + "/" + itemBankProps.getBankKey() + "-" + itemId;
+        return ivsServiceProps.getExternalHost() + ivsServiceProps.getItemMapping() + "/" + itemBankProps.getBankKey() + "-" + itemId;
     }
 
     private RestTemplate getPooledRestTemplate() {

--- a/src/main/java/org/opentestsystem/ap/irs/config/IvsServiceProperties.java
+++ b/src/main/java/org/opentestsystem/ap/irs/config/IvsServiceProperties.java
@@ -24,6 +24,8 @@ public class IvsServiceProperties {
 
     public String host;
 
+    public String externalHost;
+
     public String reloadEndpoint;
 
     public String itemMapping;

--- a/src/test/java/org/opentestsystem/ap/irs/config/NoItemBankConfig.java
+++ b/src/test/java/org/opentestsystem/ap/irs/config/NoItemBankConfig.java
@@ -10,7 +10,7 @@ package org.opentestsystem.ap.irs.config;
 import org.opentestsystem.ap.common.client.GitlabClient;
 import org.opentestsystem.ap.common.config.ItemBankProperties;
 import org.opentestsystem.ap.common.model.ItemFactory;
-import org.opentestsystem.ap.common.util.ItemIdGenerator;
+import org.opentestsystem.ap.common.saaif.SaaifIdGenerator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
@@ -38,8 +38,8 @@ public class NoItemBankConfig {
     }
 
     @Bean
-    public ItemIdGenerator itemIdGenerator() {
-        return new ItemIdGenerator(props.getIdMinValue(), props.getIdMaxValue());
+    public SaaifIdGenerator itemIdGenerator() {
+        return new SaaifIdGenerator(props.getIdMinValue(), props.getIdMaxValue());
     }
 
     @Bean

--- a/src/test/java/org/opentestsystem/ap/irs/config/NoRedisSessionConfig.java
+++ b/src/test/java/org/opentestsystem/ap/irs/config/NoRedisSessionConfig.java
@@ -9,7 +9,7 @@ package org.opentestsystem.ap.irs.config;
 
 import org.opentestsystem.ap.common.config.ItemBankProperties;
 import org.opentestsystem.ap.common.model.ItemFactory;
-import org.opentestsystem.ap.common.util.ItemIdGenerator;
+import org.opentestsystem.ap.common.saaif.SaaifIdGenerator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
@@ -31,8 +31,8 @@ public class NoRedisSessionConfig {
     }
 
     @Bean
-    public ItemIdGenerator itemIdGenerator() {
-        return new ItemIdGenerator(props.getIdMinValue(), props.getIdMaxValue());
+    public SaaifIdGenerator itemIdGenerator() {
+        return new SaaifIdGenerator(props.getIdMinValue(), props.getIdMaxValue());
     }
 
     @Bean


### PR DESCRIPTION
* Added IVS `externalHost` configuration property to allow IVS rendering to occur when service is running in a docker container. The `host` property is used to execute the internal IVS calls. The `externalHost` is used to return a publicly accessible  URL to caller
* Updated AP_Common version
* Updated unit test