### PR TITLE
IAT-539:  Updated to ap-common 0.1.12-SNAPSHOT that has breaking chan…

### DIFF
--- a/application.yml
+++ b/application.yml
@@ -34,14 +34,14 @@ spring:
     enabled: "${SESSION_CLUSTER_ENABLED:true}"
 
 itembank:
-  host: "${GITLAB_HOST:https://gitlab-dev.smarterbalanced.org}"
+  host: "https://gitlab-dev.smarterbalanced.org"
   accessToken: "${GITLAB_ACCESS_TOKEN}"
   user: "${GITLAB_USER}"
   password: "${GITLAB_PASSWORD}"
-  group: "${GITLAB_GROUP:iat-development}"
-  localBaseDir: "${GITLAB_LOCAL_BASE_DIR:${HOME}/ItemBankIRS}"
-  apiVersion: "${GITLAB_API_VERSION:/api/v4}"
-  bankKey: "${GITLAB_BANK_KEY:187}"
+  group: "${GITLAB_GROUP}"
+  localBaseDir: "${HOME}/ItemBankIRS"
+  apiVersion: "/api/v4"
+  bankKey: "187"
 
 ivs:
   host: "${IVS_HOST:http://localhost:8200}"
@@ -49,3 +49,10 @@ ivs:
   reloadEndpoint: "${IVS_RELOAD_ENDPOINT:/Pages/API/content/reload}"
   itemMapping: "${IVS_ITEM_MAPPING:/item}"
   ivsBaseDir: "${IVS_BASE_DIR:${HOME}/ItemBankIVS}"
+
+---
+spring:
+  profiles: dev
+
+itembank:
+  group: "iat-development"

--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ repositories {
 }
 
 dependencies {
-    compile 'org.opentestsystem.ap:ap-common:0.1.11'
+    compile 'org.opentestsystem.ap:ap-common:0.1.12-SNAPSHOT'
 
     compile 'org.springframework.boot:spring-boot-starter-actuator'
     compile 'org.springframework.boot:spring-boot-starter-security'

--- a/src/test/java/org/opentestsystem/ap/irs/config/NoItemBankConfig.java
+++ b/src/test/java/org/opentestsystem/ap/irs/config/NoItemBankConfig.java
@@ -10,6 +10,7 @@ package org.opentestsystem.ap.irs.config;
 import org.opentestsystem.ap.common.client.GitlabClient;
 import org.opentestsystem.ap.common.config.ItemBankProperties;
 import org.opentestsystem.ap.common.model.ItemFactory;
+import org.opentestsystem.ap.common.saaif.SaaifIdDigitGenerator;
 import org.opentestsystem.ap.common.saaif.SaaifIdGenerator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -39,7 +40,7 @@ public class NoItemBankConfig {
 
     @Bean
     public SaaifIdGenerator itemIdGenerator() {
-        return new SaaifIdGenerator(props.getIdMinValue(), props.getIdMaxValue());
+        return new SaaifIdDigitGenerator(props.getIdMinValue(), props.getIdMaxValue());
     }
 
     @Bean

--- a/src/test/java/org/opentestsystem/ap/irs/config/NoRedisSessionConfig.java
+++ b/src/test/java/org/opentestsystem/ap/irs/config/NoRedisSessionConfig.java
@@ -9,6 +9,7 @@ package org.opentestsystem.ap.irs.config;
 
 import org.opentestsystem.ap.common.config.ItemBankProperties;
 import org.opentestsystem.ap.common.model.ItemFactory;
+import org.opentestsystem.ap.common.saaif.SaaifIdDigitGenerator;
 import org.opentestsystem.ap.common.saaif.SaaifIdGenerator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -32,7 +33,7 @@ public class NoRedisSessionConfig {
 
     @Bean
     public SaaifIdGenerator itemIdGenerator() {
-        return new SaaifIdGenerator(props.getIdMinValue(), props.getIdMaxValue());
+        return new SaaifIdDigitGenerator(props.getIdMinValue(), props.getIdMaxValue());
     }
 
     @Bean


### PR DESCRIPTION
…ges

I simplified the root level application.yml.  It does mean we need to have an env var set called GITLAB_GROUP which should be set to your new group iat-alex.  

If  you want to run against iat-development you should run IRS with the SPRING_PROFILES_ACTIVE=dev