### PR TITLE
Feature/iat 752

### DIFF
--- a/application.yml
+++ b/application.yml
@@ -49,6 +49,15 @@ ivs:
   reloadEndpoint: "${IVS_RELOAD_ENDPOINT:/Pages/API/content/reload}"
   itemMapping: "${IVS_ITEM_MAPPING:/item}"
   ivsBaseDir: "${IVS_BASE_DIR:${HOME}/ItemBankIVS}"
+  cleanupThresholdHours: "1"
+
+cleanupIrsBaseDir:
+  in:
+    milliseconds: "30000"
+
+cleanupIvsBaseDir:
+  in:
+    milliseconds: "30000"
 
 ---
 spring:

--- a/application.yml
+++ b/application.yml
@@ -51,13 +51,11 @@ ivs:
   ivsBaseDir: "${IVS_BASE_DIR:${HOME}/ItemBankIVS}"
   cleanupThresholdHours: "1"
 
-cleanupIrsBaseDir:
-  in:
-    milliseconds: "30000"
-
-cleanupIvsBaseDir:
-  in:
-    milliseconds: "30000"
+tasks:
+  irsItemCleanupThresholdMillis : "30000"
+  irsItemCleanupRunEveryMillis: "30000"
+  ivsItemCleanupThresholdMillis : "30000"
+  ivsItemCleanupRunEveryMillis: "30000"
 
 ---
 spring:

--- a/src/main/java/org/opentestsystem/ap/irs/IRSApplication.java
+++ b/src/main/java/org/opentestsystem/ap/irs/IRSApplication.java
@@ -9,24 +9,25 @@
  * in an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for
  * specific language governing permissions and limitations under the license.
  */
-
 package org.opentestsystem.ap.irs;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.scheduling.annotation.EnableScheduling;
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
+@EnableScheduling
 @EnableSwagger2
 @SpringBootApplication
 @ComponentScan({"org.opentestsystem.ap.irs", "org.opentestsystem.ap.common"})
 public class IRSApplication {
 
     static {
-		System.setProperty("javax.xml.bind.context.factory", "org.eclipse.persistence.jaxb.JAXBContextFactory");
-	}
+        System.setProperty("javax.xml.bind.context.factory", "org.eclipse.persistence.jaxb.JAXBContextFactory");
+    }
 
-	public static void main(String[] args) {
-		SpringApplication.run(IRSApplication.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(IRSApplication.class, args);
+    }
 }

--- a/src/main/java/org/opentestsystem/ap/irs/config/IvsServiceProperties.java
+++ b/src/main/java/org/opentestsystem/ap/irs/config/IvsServiceProperties.java
@@ -31,4 +31,6 @@ public class IvsServiceProperties {
     private String itemMapping;
 
     private String ivsBaseDir;
+
+    private int cleanupThresholdHours = 1;
 }

--- a/src/main/java/org/opentestsystem/ap/irs/config/TaskProperties.java
+++ b/src/main/java/org/opentestsystem/ap/irs/config/TaskProperties.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017 Regents of the University of California. Licensed under the Educational Community License, Version
+ * 2.0 (the "license"); you may not use this file except in compliance with the License. You may obtain a copy of the
+ * license at
+ *
+ * https://opensource.org/licenses/ECL-2.0
+ *
+ * Unless required under applicable law or agreed to in writing, software distributed under the License is distributed
+ * in an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for
+ * specific language governing permissions and limitations under the license.
+ */
+package org.opentestsystem.ap.irs.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "tasks")
+public class TaskProperties {
+
+    private int irsItemCleanupThresholdMillis;
+
+    private int irsItemCleanupRunEveryMillis;
+
+    private int ivsItemCleanupThresholdMillis;
+
+    private int ivsItemCleanupRunEveryMillis;
+}

--- a/src/main/java/org/opentestsystem/ap/irs/task/ItemCleanupTask.java
+++ b/src/main/java/org/opentestsystem/ap/irs/task/ItemCleanupTask.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2017 Regents of the University of California. Licensed under the Educational Community License, Version
+ * 2.0 (the "license"); you may not use this file except in compliance with the License. You may obtain a copy of the
+ * license at
+ *
+ * https://opensource.org/licenses/ECL-2.0
+ *
+ * Unless required under applicable law or agreed to in writing, software distributed under the License is distributed
+ * in an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for
+ * specific language governing permissions and limitations under the license.
+ */
+package org.opentestsystem.ap.irs.task;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Date;
+import java.util.function.Predicate;
+
+import lombok.extern.slf4j.Slf4j;
+import org.joda.time.DateTime;
+import org.opentestsystem.ap.common.config.ItemBankProperties;
+import org.opentestsystem.ap.common.repository.ItemRepositoryUtil;
+import org.opentestsystem.ap.irs.config.IvsServiceProperties;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+/**
+ * Deletes old items from the file system.  Item data collects in the different item
+ * banks.  The items are a one time use and do not need to stay on disk for long.
+ */
+public class ItemCleanupTask {
+
+    private final ItemBankProperties itemBankProperties;
+
+    private final IvsServiceProperties ivsServiceProperties;
+
+    public ItemCleanupTask(final ItemBankProperties itemBankProperties,
+                           final IvsServiceProperties ivsServiceProperties) {
+        this.itemBankProperties = itemBankProperties;
+        this.ivsServiceProperties = ivsServiceProperties;
+    }
+
+    @Scheduled(fixedRateString = "${cleanupIrsBaseDir.in.milliseconds}")
+    public void cleanupIrsBaseDir() {
+        log.debug("cleanupIrsBaseDir: start");
+
+        final Path path = Paths.get(itemBankProperties.getLocalBaseDir());
+
+        final Date cleanupThresholdDate = new DateTime()
+            .minusHours(ivsServiceProperties.getCleanupThresholdHours())
+            .toDate();
+
+        cleanupFolder(path, cleanupThresholdDate);
+
+        log.debug("cleanupIrsBaseDir: end");
+    }
+
+    @Scheduled(fixedRateString = "${cleanupIvsBaseDir.in.milliseconds}")
+    public void cleanupIvsBaseDir() {
+        log.debug("cleanupIvsBaseDir: start");
+
+        final Path path = Paths.get(ivsServiceProperties.getIvsBaseDir());
+
+        final Date cleanupThresholdDate = new DateTime()
+            .minusHours(ivsServiceProperties.getCleanupThresholdHours())
+            .toDate();
+
+        cleanupFolder(path, cleanupThresholdDate);
+
+        log.debug("cleanupIvsBaseDir: end");
+    }
+
+    private void cleanupFolder(final Path rootPath, final Date cleanupThresholdDate) {
+        log.debug("cleanupFolder: path {}, threshold {}", rootPath, cleanupThresholdDate);
+        try {
+            Files.walk(rootPath, 1)
+                .filter(Files::isDirectory)
+                .filter(isFolderOlderThan(cleanupThresholdDate))
+                .forEach(ItemRepositoryUtil::deleteDirectory);
+        } catch (IOException e) {
+            log.error("cleanupFolder: Error getting list of folders in " + rootPath.toString(), e);
+        }
+    }
+
+    /**
+     * If the path last modified date is before the given date true is returned.  False otherwise.
+     *
+     * @param date The date to compare the path last modified data against.
+     * @return If the path last modified date is before the given date true is returned.  False otherwise.
+     */
+    private Predicate<Path> isFolderOlderThan(final Date date) {
+        return path -> path.toFile().lastModified() < date.getTime();
+    }
+}

--- a/src/main/java/org/opentestsystem/ap/irs/task/ItemCleanupTask.java
+++ b/src/main/java/org/opentestsystem/ap/irs/task/ItemCleanupTask.java
@@ -19,10 +19,12 @@ import java.util.Date;
 import java.util.function.Predicate;
 
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.joda.time.DateTime;
 import org.opentestsystem.ap.common.config.ItemBankProperties;
 import org.opentestsystem.ap.common.repository.ItemRepositoryUtil;
 import org.opentestsystem.ap.irs.config.IvsServiceProperties;
+import org.opentestsystem.ap.irs.config.TaskProperties;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -34,51 +36,56 @@ import org.springframework.stereotype.Component;
  */
 public class ItemCleanupTask {
 
+    private final TaskProperties taskProperties;
+
     private final ItemBankProperties itemBankProperties;
 
     private final IvsServiceProperties ivsServiceProperties;
 
-    public ItemCleanupTask(final ItemBankProperties itemBankProperties,
+    public ItemCleanupTask(final TaskProperties taskProperties,
+                           final ItemBankProperties itemBankProperties,
                            final IvsServiceProperties ivsServiceProperties) {
+        this.taskProperties = taskProperties;
         this.itemBankProperties = itemBankProperties;
         this.ivsServiceProperties = ivsServiceProperties;
     }
 
-    @Scheduled(fixedRateString = "${cleanupIrsBaseDir.in.milliseconds}")
-    public void cleanupIrsBaseDir() {
-        log.debug("cleanupIrsBaseDir: start");
+    @Scheduled(fixedRateString = "${tasks.irsItemCleanupRunEveryMillis}")
+    public void cleanupOldItemsFromIRSBaseDir() {
+        log.debug("IRS file cleanup: start");
 
         final Path path = Paths.get(itemBankProperties.getLocalBaseDir());
 
         final Date cleanupThresholdDate = new DateTime()
-            .minusHours(ivsServiceProperties.getCleanupThresholdHours())
+            .minusMillis(taskProperties.getIrsItemCleanupThresholdMillis())
             .toDate();
 
         cleanupFolder(path, cleanupThresholdDate);
 
-        log.debug("cleanupIrsBaseDir: end");
+        log.debug("IRS file cleanup: end");
     }
 
-    @Scheduled(fixedRateString = "${cleanupIvsBaseDir.in.milliseconds}")
-    public void cleanupIvsBaseDir() {
-        log.debug("cleanupIvsBaseDir: start");
+    @Scheduled(fixedRateString = "${tasks.ivsItemCleanupRunEveryMillis}")
+    public void cleanupOldItemFromIVSBaseDir() {
+        log.debug("IVS file cleanup: start");
 
         final Path path = Paths.get(ivsServiceProperties.getIvsBaseDir());
 
         final Date cleanupThresholdDate = new DateTime()
-            .minusHours(ivsServiceProperties.getCleanupThresholdHours())
+            .minusMillis(taskProperties.getIvsItemCleanupThresholdMillis())
             .toDate();
 
         cleanupFolder(path, cleanupThresholdDate);
 
-        log.debug("cleanupIvsBaseDir: end");
+        log.debug("IVS file cleanup: end");
     }
 
     private void cleanupFolder(final Path rootPath, final Date cleanupThresholdDate) {
         log.debug("cleanupFolder: path {}, threshold {}", rootPath, cleanupThresholdDate);
         try {
-            Files.walk(rootPath, 1)
+            Files.walk(rootPath, 2)
                 .filter(Files::isDirectory)
+                .filter(isNotRootPath(rootPath))
                 .filter(isFolderOlderThan(cleanupThresholdDate))
                 .forEach(ItemRepositoryUtil::deleteDirectory);
         } catch (IOException e) {
@@ -94,5 +101,9 @@ public class ItemCleanupTask {
      */
     private Predicate<Path> isFolderOlderThan(final Date date) {
         return path -> path.toFile().lastModified() < date.getTime();
+    }
+
+    private Predicate<Path> isNotRootPath(final Path rootPath) {
+        return path -> !StringUtils.equals(rootPath.toString(), path.toString());
     }
 }


### PR DESCRIPTION
Two scheduled tasks:
1. cleanup the IRS local folder
2. cleanup the shared folder used by IVS and IRS

I didn't use cron.  I used the Spring scheduling capability.  It seemed like a better route to go because we have all the configuration built into the app so the scheduled job can utilize it.  For instance the configured folders where IRS writes and IVS reads. 