### PR TITLE
Prepare for running in docker-compose and CI environments

### DIFF
--- a/application.yml
+++ b/application.yml
@@ -15,13 +15,6 @@
 server:
   port: 8083
 
-security:
-  basic:
-    enabled: "${SECURITY_ENABLED:true}"
-  user:
-    name: "admin"
-    password: "admin"
-
 logging:
   level:
     org:
@@ -29,50 +22,6 @@ logging:
         ap:
           irs: "debug"
           common: "debug"
-
-spring:
-  session:
-    enabled: "${SESSION_CLUSTER_ENABLED:true}"
-  datasource:
-    url: "jdbc:postgresql://localhost:5432/iat"
-    username: "${DB_USER}"
-    password: "${DB_PASSWORD}"
-    validationQuery: "SELECT 1"
-  jpa:
-    hibernate:
-      ddl-auto: "validate"
-    properties:
-      hibernate:
-        show_sql: true
-        use_sql_comments: true
-        format_sql: true
-
-itembank:
-  systemVersion: "iat-41"
-  localBaseDir: "${HOME}/ItemBankIVS"
-  systemUser:
-    userName: "iat-item-rendering-service@smarterbalanced.org"
-    fullName: "Item Rendering Service"
-  enabled:
-    database: true
-  services:
-    history:
-      url: "http://localhost:8086"
-  aws:
-    endpointUrl: "https://s3.us-east-2.amazonaws.com"
-    region: "us-east-2"
-    bucketName: "${GITLAB_GROUP}"
-    versionedBucketName: "${GITLAB_GROUP}-versioned"
-    accessKey: "${IAT_AWS_ACCESS_KEY}"
-    secretKey: "${IAT_AWS_ACCESS_SECRET}"
-  preview:
-    host: "${IVS_HOST:/iatpreview}"
-    externalHost: "${IVS_HOST:/iatpreview}"
-    ivsBaseDir: "${IVS_BASE_DIR:${HOME}/ItemBankIVS}"
-
-tasks:
-  itemCleanupThresholdMillis : "1800000000"
-  itemCleanupRunEveryMillis: "1800000000"
 
 ---
 spring:

--- a/build.gradle
+++ b/build.gradle
@@ -218,16 +218,19 @@ task dockerCopyFiles(type: Copy) {
 task dockerBuildImage(type: DockerBuildImage) {
     dependsOn 'dockerCopyFiles'
     inputDir = project.file('build/docker/')
-    tag = "${project.dockerTagBase}/${jar.baseName}:${project.version}"
+    def name = "${dockerTagBase}/${jar.baseName}" + (project.version.contains('-SNAPSHOT') ? "": ":${project.version}")
+    tags.add(name.toString())
 }
 
 task dockerPushImage(type: DockerPushImage) {
     dependsOn 'dockerBuildImage'
-    imageName = "${project.dockerTagBase}/${jar.baseName}:${project.version}"
+    def name = "${dockerTagBase}/${jar.baseName}" + (project.version.contains('-SNAPSHOT') ? "": ":${project.version}")
+    imageName = name.toString()
 }
 
 task dockerRemoveImage(type: DockerRemoveImage) {
-    imageId = "${project.dockerTagBase}/${jar.baseName}:${project.version}"
+    def name = "${dockerTagBase}/${jar.baseName}" + (project.version.contains('-SNAPSHOT') ? "": ":${project.version}")
+    imageId = name.toString()
 }
 
 /***************************

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -19,6 +19,4 @@ RUN apt-get -y install curl libunwind8 gettext apt-transport-https
 
 RUN apt-get -y install jq
 
-ENTRYPOINT ["/usr/bin/java"]
-
-CMD ["-jar", "/ap-irs.jar"]
+CMD ["java", "-jar", "/ap-irs.jar"]

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -19,4 +19,6 @@ RUN apt-get -y install curl libunwind8 gettext apt-transport-https
 
 RUN apt-get -y install jq
 
-CMD ["java", "-jar", "/ap-irs.jar"]
+ENV MAX_HEAP_SIZE -Xmx384m
+
+CMD java $MAX_HEAP_SIZE $JAVA_OPTS -jar ap-irs.jar

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,3 +19,51 @@ management:
 
 api:
   context-path: "/api"
+
+security:
+  basic:
+    enabled: \${SECURITY_ENABLED:true}
+
+spring:
+  session:
+    enabled: \${SESSION_CLUSTER_ENABLED:true}
+  datasource:
+    url: "jdbc:postgresql://localhost:5432/iat"
+    username: \${DB_USER}
+    password: \${DB_PASSWORD}
+    validationQuery: "SELECT 1"
+  jpa:
+    hibernate:
+      ddl-auto: "validate"
+    properties:
+      hibernate:
+        show_sql: true
+        use_sql_comments: true
+        format_sql: true
+
+itembank:
+  systemVersion: "iat-41"
+  localBaseDir: \${HOME}/ItemBankIVS
+  systemUser:
+    userName: "iat-item-rendering-service@smarterbalanced.org"
+    fullName: "Item Rendering Service"
+  enabled:
+    database: true
+  services:
+    history:
+      url: "http://localhost:8086"
+  aws:
+    endpointUrl: "https://s3.us-east-2.amazonaws.com"
+    region: "us-east-2"
+    bucketName: \${GITLAB_GROUP}
+    versionedBucketName: \${GITLAB_GROUP}-versioned
+    accessKey: \${IAT_AWS_ACCESS_KEY}
+    secretKey: \${IAT_AWS_ACCESS_SECRET}
+  preview:
+    host: \${IVS_HOST:/iatpreview}
+    externalHost: \${IVS_HOST:/iatpreview}
+    ivsBaseDir: \${IVS_BASE_DIR:\${HOME}/ItemBankIVS}
+
+tasks:
+  itemCleanupThresholdMillis : "1800000000"
+  itemCleanupRunEveryMillis: "1800000000"


### PR DESCRIPTION
Sample docker-compose:
```
  # Item Rendering Service
  ap-irs:
    image: fwsbac/ap-irs:latest
    ports:
      - 8083:8080
    volumes:
      - ${HOME}:/home
    environment:
      - HOME=/home
      - SPRING_REDIS_HOST=host.docker.internal
      - SPRING_RABBITMQ_HOST=host.docker.internal
      - SPRING_DATASOURCE_URL=jdbc:postgresql://host.docker.internal:5432/iat
      - SECURITY_ENABLED
      - SESSION_CLUSTER_ENABLED
      - DB_USER
      - DB_PASSWORD
      - GITLAB_GROUP
      - IAT_AWS_ACCESS_KEY
      - IAT_AWS_ACCESS_SECRET
      - IVS_HOST
      - IVS_BASE_DIR
```