### PR TITLE
Made RequestParam 'associatedIds' non-required

### DIFF
--- a/src/main/java/org/opentestsystem/ap/irs/RenderingApi.java
+++ b/src/main/java/org/opentestsystem/ap/irs/RenderingApi.java
@@ -47,7 +47,7 @@ public class RenderingApi {
 
     @GetMapping("/{itemId}")
     public RenderResponse renderItem(@PathVariable final String itemId,
-                                     @RequestParam("associationIds") final String associationIds) {
+                                     @RequestParam(value = "associationIds", required = false) final String associationIds) {
 
         final List<String> associationIdList = parseCommaSeparatedString(associationIds);
         return renderingService.renderItem(itemId, associationIdList);
@@ -56,7 +56,7 @@ public class RenderingApi {
     @GetMapping("/{itemId}/{itemHistoryId}")
     public RenderResponse renderItem(@PathVariable String itemId,
                                      @PathVariable String itemHistoryId,
-                                     @RequestParam("associationIds") final String associationIds) {
+                                     @RequestParam(value = "associationIds", required = false) final String associationIds) {
         final List<String> associationIdList = parseCommaSeparatedString(associationIds);
         return renderingService.renderItem(itemId, itemHistoryId, associationIdList);
     }


### PR DESCRIPTION
Began getting the following exception after pulling latest from develop branch:

`Resolved exception caused by Handler execution: org.springframework.web.bind.MissingServletRequestParameterException: Required String parameter 'associationIds' is not present`

After reviewing with @bdrainer, we identified that a recent update changed the `associationId` param from `QueryParam` to `RequestParam`. This change made this value required. A valid scenario does not require this value from being passed.

The change is to make the RequestPara `required = false`